### PR TITLE
Enable package prefetching for go mod

### DIFF
--- a/.tekton/marin3r-pull-request.yaml
+++ b/.tekton/marin3r-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/marin3r-push.yaml
+++ b/.tekton/marin3r-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -99,6 +101,7 @@ spec:
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
+
     - default: "false"
       description: Java build
       name: java


### PR DESCRIPTION
as per docs: https://konflux-ci.dev/docs/how-tos/configuring/prefetching-dependencies/#enabling-prefetch-builds-for-gomod

This is necessary in order to be able to run hermetic builds.