### PR TITLE
enable operator and operator bundle pipelines

### DIFF
--- a/.tekton/marin3r-operator-bundle-pull-request.yaml
+++ b/.tekton/marin3r-operator-bundle-pull-request.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/single-arch-build-pipeline.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-bundle-pull-request.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-bundle-push.yaml".pathChanged() ||
+      "bundle.Dockerfile".pathChanged() ||
+      "bundle".pathChanged() ||
+      "hack/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: marin3r
+    appstudio.openshift.io/component: marin3r-operator-bundle
+    pipelines.appstudio.openshift.io/type: build
+  name: marin3r-operator-bundle-on-pull-request
+  namespace: rh-ee-gsaslisl-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r-operator-bundle:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: bundle.Dockerfile
+    - name: hermetic
+      value: "false"
+  pipelineRef:
+    name: single-arch-build-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/.tekton/marin3r-operator-bundle-push.yaml
+++ b/.tekton/marin3r-operator-bundle-push.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/single-arch-build-pipeline.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-bundle-pull-request.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-bundle-push.yaml".pathChanged() ||
+      "bundle.Dockerfile".pathChanged() ||
+      "bundle".pathChanged() ||
+      "hack/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: marin3r
+    appstudio.openshift.io/component: marin3r-operator-bundle
+    pipelines.appstudio.openshift.io/type: build
+  name: marin3r-operator-bundle-on-push
+  namespace: rh-ee-gsaslisl-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r-operator-bundle:{{revision}}
+    - name: dockerfile
+      value: bundle.Dockerfile
+    # Do not use hermetic for now as we are going to generate our manifest at build time. We need to pull in content.
+    - name: hermetic
+      value: "false"
+  pipelineRef:
+    name: single-arch-build-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/.tekton/marin3r-operator-pull-request.yaml
+++ b/.tekton/marin3r-operator-pull-request.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/multi-arch-build-pipeline.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-pull-request.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-push.yaml".pathChanged() ||
+      "Dockerfile".pathChanged() ||
+      "apis".pathChanged()) ||
+      "cmd".pathChanged()) ||
+      "config".pathChanged()) ||
+      "controllers".pathChanged()) ||
+      "docs".pathChanged()) ||
+      "examples".pathChanged()) ||
+      "examples".pathChanged()) ||
+      "generators".pathChanged()) ||
+      "pkg".pathChanged()) ||
+      "test".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: marin3r
+    appstudio.openshift.io/component: marin3r-operator
+    pipelines.appstudio.openshift.io/type: build
+  name: marin3r-operator-on-pull-request
+  namespace: rh-ee-gsaslisl-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r-operator:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+#    - name: prefetch-input
+#      value: '{"type": "gomod", "path": "."}'
+#    - name: hermetic
+#      value: "true"
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/.tekton/marin3r-operator-push.yaml
+++ b/.tekton/marin3r-operator-push.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_bundle.sh"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/multi-arch-build-pipeline.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-pull-request.yaml".pathChanged() ||
+      ".tekton/marin3r-operator-push.yaml".pathChanged() ||
+      "Dockerfile".pathChanged() ||
+      "apis".pathChanged()) ||
+      "cmd".pathChanged()) ||
+      "config".pathChanged()) ||
+      "controllers".pathChanged()) ||
+      "docs".pathChanged()) ||
+      "examples".pathChanged()) ||
+      "examples".pathChanged()) ||
+      "generators".pathChanged()) ||
+      "pkg".pathChanged()) ||
+      "test".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: marin3r
+    appstudio.openshift.io/component: marin3r-operator
+    pipelines.appstudio.openshift.io/type: build
+  name: marin3r-operator-on-push
+  namespace: rh-ee-gsaslisl-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r-operator:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+#    - name: prefetch-input
+#      value: '{"type": "gomod", "path": "."}'
+#    - name: hermetic
+#      value: "true"
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/.tekton/marin3r-pull-request.yaml
+++ b/.tekton/marin3r-pull-request.yaml
@@ -1,478 +1,478 @@
-apiVersion: tekton.dev/v1
-kind: PipelineRun
-metadata:
-  annotations:
-    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
-    build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
-    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
-  creationTimestamp: null
-  labels:
-    appstudio.openshift.io/application: marin3r
-    appstudio.openshift.io/component: marin3r
-    pipelines.appstudio.openshift.io/type: build
-  name: marin3r-on-pull-request
-  namespace: rh-ee-gsaslisl-tenant
-spec:
-  params:
-  - name: git-url
-    value: '{{source_url}}'
-  - name: revision
-    value: '{{revision}}'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
-  - name: dockerfile
-    value: Dockerfile
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
-  - name: hermetic
-    value: "true"
-  pipelineSpec:
-    finally:
-    - name: show-sbom
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      taskRef:
-        params:
-        - name: name
-          value: show-sbom
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: show-summary
-      params:
-      - name: pipelinerun-name
-        value: $(context.pipelineRun.name)
-      - name: git-url
-        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-      - name: image-url
-        value: $(params.output-image)
-      - name: build-task-status
-        value: $(tasks.build-container.status)
-      taskRef:
-        params:
-        - name: name
-          value: summary
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    params:
-    - description: Source Repository URL
-      name: git-url
-      type: string
-    - default: ""
-      description: Revision of the Source Repository
-      name: revision
-      type: string
-    - description: Fully Qualified Output Image
-      name: output-image
-      type: string
-    - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
-      name: path-context
-      type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
-      name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
-      type: string
-    - default: "false"
-      description: Skip checks against built image
-      name: skip-checks
-      type: string
-    - default: "false"
-      description: Execute the build with network isolation
-      name: hermetic
-      type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
-      name: prefetch-input
-      type: string
-    - default: "false"
-      description: Java build
-      name: java
-      type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
-      name: image-expires-after
-    - default: "false"
-      description: Build a source image.
-      name: build-source-image
-      type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
-      name: build-args
-      type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-      name: build-args-file
-      type: string
-    results:
-    - description: ""
-      name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
-    - description: ""
-      name: IMAGE_DIGEST
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
-    - description: ""
-      name: CHAINS-GIT_URL
-      value: $(tasks.clone-repository.results.url)
-    - description: ""
-      name: CHAINS-GIT_COMMIT
-      value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
-    tasks:
-    - name: init
-      params:
-      - name: image-url
-        value: $(params.output-image)
-      - name: rebuild
-        value: $(params.rebuild)
-      - name: skip-checks
-        value: $(params.skip-checks)
-      taskRef:
-        params:
-        - name: name
-          value: init
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: clone-repository
-      params:
-      - name: url
-        value: $(params.git-url)
-      - name: revision
-        value: $(params.revision)
-      runAfter:
-      - init
-      taskRef:
-        params:
-        - name: name
-          value: git-clone
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: output
-        workspace: workspace
-      - name: basic-auth
-        workspace: git-auth
-    - name: prefetch-dependencies
-      params:
-      - name: input
-        value: $(params.prefetch-input)
-      runAfter:
-      - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: prefetch-dependencies
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:398d8333d30ea25ec1f766009c960df8dd42e0e3af7b2d782236dbde9a9f4bd9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.prefetch-input)
-        operator: notin
-        values:
-        - ""
-      workspaces:
-      - name: source
-        workspace: workspace
-      - name: git-basic-auth
-        workspace: git-auth
-      - name: netrc
-        workspace: netrc
-    - name: build-container
-      params:
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      runAfter:
-      - prefetch-dependencies
-      taskRef:
-        params:
-        - name: name
-          value: buildah
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:f93024e3dbcd41dcf1d7e30b3151032808211c39ad0a5ea03ea9c4d5274fa8dd
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: source
-        workspace: workspace
-    - name: build-source-image
-      params:
-      - name: BINARY_IMAGE
-        value: $(params.output-image)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: source-build
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.1@sha256:1cb3423593145e899b784000f6ae90e121763ce98c26f6fc049f5dee2310f805
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      - input: $(params.build-source-image)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    - name: deprecated-base-image-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: deprecated-image-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:3ac359dfc034948d59b9e8d507a8cf505a19b205c543e4c861a332c6f82a0307
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:a4dc853e50a31272d45aef8e8bdc7dac0f0f92212fc7bf8bab67ba5917c03405
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.1@sha256:9268ed0a50a87f27aedc048f69dff69b2a68d5aa3aca9ab7b65fe5a9f235d0c2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    - name: clamav-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clamav-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b494d21c755f5142f74441df3dc204a1d357a0fc339ac5a8000b80dc983182f9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:80a4d5df9d56b93a98fdca5d5fa6d7ecdb9731cdffd1c16bf51ee11e49984140
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: apply-tags
-      params:
-      - name: IMAGE
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: apply-tags
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: push-dockerfile
-      params:
-      - name: IMAGE
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: push-dockerfile
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:e2c8fa67da036cef81e407e28c14b6a2034c6564009e084c368005a4640c554c
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    workspaces:
-    - name: workspace
-    - name: git-auth
-      optional: true
-    - name: netrc
-      optional: true
-  taskRunTemplate: {}
-  workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-      status: {}
-  - name: git-auth
-    secret:
-      secretName: '{{ git_auth_secret }}'
-status: {}
+#apiVersion: tekton.dev/v1
+#kind: PipelineRun
+#metadata:
+#  annotations:
+#    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+#    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+#    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+#    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+#    pipelinesascode.tekton.dev/max-keep-runs: "3"
+#    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+#      == "main"
+#  creationTimestamp: null
+#  labels:
+#    appstudio.openshift.io/application: marin3r
+#    appstudio.openshift.io/component: marin3r
+#    pipelines.appstudio.openshift.io/type: build
+#  name: marin3r-on-pull-request
+#  namespace: rh-ee-gsaslisl-tenant
+#spec:
+#  params:
+#  - name: git-url
+#    value: '{{source_url}}'
+#  - name: revision
+#    value: '{{revision}}'
+#  - name: output-image
+#    value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r:on-pr-{{revision}}
+#  - name: image-expires-after
+#    value: 5d
+#  - name: dockerfile
+#    value: Dockerfile
+#  - name: prefetch-input
+#    value: '{"type": "gomod", "path": "."}'
+#  - name: hermetic
+#    value: "true"
+#  pipelineSpec:
+#    finally:
+#    - name: show-sbom
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: show-sbom
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: show-summary
+#      params:
+#      - name: pipelinerun-name
+#        value: $(context.pipelineRun.name)
+#      - name: git-url
+#        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+#      - name: image-url
+#        value: $(params.output-image)
+#      - name: build-task-status
+#        value: $(tasks.build-container.status)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: summary
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    params:
+#    - description: Source Repository URL
+#      name: git-url
+#      type: string
+#    - default: ""
+#      description: Revision of the Source Repository
+#      name: revision
+#      type: string
+#    - description: Fully Qualified Output Image
+#      name: output-image
+#      type: string
+#    - default: .
+#      description: Path to the source code of an application's component from where
+#        to build image.
+#      name: path-context
+#      type: string
+#    - default: Dockerfile
+#      description: Path to the Dockerfile inside the context specified by parameter
+#        path-context
+#      name: dockerfile
+#      type: string
+#    - default: "false"
+#      description: Force rebuild image
+#      name: rebuild
+#      type: string
+#    - default: "false"
+#      description: Skip checks against built image
+#      name: skip-checks
+#      type: string
+#    - default: "false"
+#      description: Execute the build with network isolation
+#      name: hermetic
+#      type: string
+#    - default: ""
+#      description: Build dependencies to be prefetched by Cachi2
+#      name: prefetch-input
+#      type: string
+#    - default: "false"
+#      description: Java build
+#      name: java
+#      type: string
+#    - default: ""
+#      description: Image tag expiration time, time values could be something like
+#        1h, 2d, 3w for hours, days, and weeks, respectively.
+#      name: image-expires-after
+#    - default: "false"
+#      description: Build a source image.
+#      name: build-source-image
+#      type: string
+#    - default: []
+#      description: Array of --build-arg values ("arg=value" strings) for buildah
+#      name: build-args
+#      type: array
+#    - default: ""
+#      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+#      name: build-args-file
+#      type: string
+#    results:
+#    - description: ""
+#      name: IMAGE_URL
+#      value: $(tasks.build-container.results.IMAGE_URL)
+#    - description: ""
+#      name: IMAGE_DIGEST
+#      value: $(tasks.build-container.results.IMAGE_DIGEST)
+#    - description: ""
+#      name: CHAINS-GIT_URL
+#      value: $(tasks.clone-repository.results.url)
+#    - description: ""
+#      name: CHAINS-GIT_COMMIT
+#      value: $(tasks.clone-repository.results.commit)
+#    - description: ""
+#      name: JAVA_COMMUNITY_DEPENDENCIES
+#      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+#    tasks:
+#    - name: init
+#      params:
+#      - name: image-url
+#        value: $(params.output-image)
+#      - name: rebuild
+#        value: $(params.rebuild)
+#      - name: skip-checks
+#        value: $(params.skip-checks)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: init
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: clone-repository
+#      params:
+#      - name: url
+#        value: $(params.git-url)
+#      - name: revision
+#        value: $(params.revision)
+#      runAfter:
+#      - init
+#      taskRef:
+#        params:
+#        - name: name
+#          value: git-clone
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: output
+#        workspace: workspace
+#      - name: basic-auth
+#        workspace: git-auth
+#    - name: prefetch-dependencies
+#      params:
+#      - name: input
+#        value: $(params.prefetch-input)
+#      runAfter:
+#      - clone-repository
+#      taskRef:
+#        params:
+#        - name: name
+#          value: prefetch-dependencies
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:398d8333d30ea25ec1f766009c960df8dd42e0e3af7b2d782236dbde9a9f4bd9
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.prefetch-input)
+#        operator: notin
+#        values:
+#        - ""
+#      workspaces:
+#      - name: source
+#        workspace: workspace
+#      - name: git-basic-auth
+#        workspace: git-auth
+#      - name: netrc
+#        workspace: netrc
+#    - name: build-container
+#      params:
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      runAfter:
+#      - prefetch-dependencies
+#      taskRef:
+#        params:
+#        - name: name
+#          value: buildah
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:f93024e3dbcd41dcf1d7e30b3151032808211c39ad0a5ea03ea9c4d5274fa8dd
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: source
+#        workspace: workspace
+#    - name: build-source-image
+#      params:
+#      - name: BINARY_IMAGE
+#        value: $(params.output-image)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: source-build
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.1@sha256:1cb3423593145e899b784000f6ae90e121763ce98c26f6fc049f5dee2310f805
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      - input: $(params.build-source-image)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    - name: deprecated-base-image-check
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: deprecated-image-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: clair-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clair-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:3ac359dfc034948d59b9e8d507a8cf505a19b205c543e4c861a332c6f82a0307
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:a4dc853e50a31272d45aef8e8bdc7dac0f0f92212fc7bf8bab67ba5917c03405
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: sast-snyk-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-snyk-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.1@sha256:9268ed0a50a87f27aedc048f69dff69b2a68d5aa3aca9ab7b65fe5a9f235d0c2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    - name: clamav-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clamav-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b494d21c755f5142f74441df3dc204a1d357a0fc339ac5a8000b80dc983182f9
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: sbom-json-check
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sbom-json-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:80a4d5df9d56b93a98fdca5d5fa6d7ecdb9731cdffd1c16bf51ee11e49984140
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: apply-tags
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: apply-tags
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: push-dockerfile
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: push-dockerfile
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:e2c8fa67da036cef81e407e28c14b6a2034c6564009e084c368005a4640c554c
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    workspaces:
+#    - name: workspace
+#    - name: git-auth
+#      optional: true
+#    - name: netrc
+#      optional: true
+#  taskRunTemplate: {}
+#  workspaces:
+#  - name: workspace
+#    volumeClaimTemplate:
+#      metadata:
+#        creationTimestamp: null
+#      spec:
+#        accessModes:
+#        - ReadWriteOnce
+#        resources:
+#          requests:
+#            storage: 1Gi
+#      status: {}
+#  - name: git-auth
+#    secret:
+#      secretName: '{{ git_auth_secret }}'
+#status: {}

--- a/.tekton/marin3r-push.yaml
+++ b/.tekton/marin3r-push.yaml
@@ -1,476 +1,476 @@
-apiVersion: tekton.dev/v1
-kind: PipelineRun
-metadata:
-  annotations:
-    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
-    build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
-  creationTimestamp: null
-  labels:
-    appstudio.openshift.io/application: marin3r
-    appstudio.openshift.io/component: marin3r
-    pipelines.appstudio.openshift.io/type: build
-  name: marin3r-on-push
-  namespace: rh-ee-gsaslisl-tenant
-spec:
-  params:
-  - name: git-url
-    value: '{{source_url}}'
-  - name: revision
-    value: '{{revision}}'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r:{{revision}}
-  - name: dockerfile
-    value: Dockerfile
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
-  - name: hermetic
-    value: "true"
-  pipelineSpec:
-    finally:
-    - name: show-sbom
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      taskRef:
-        params:
-        - name: name
-          value: show-sbom
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: show-summary
-      params:
-      - name: pipelinerun-name
-        value: $(context.pipelineRun.name)
-      - name: git-url
-        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-      - name: image-url
-        value: $(params.output-image)
-      - name: build-task-status
-        value: $(tasks.build-container.status)
-      taskRef:
-        params:
-        - name: name
-          value: summary
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    params:
-    - description: Source Repository URL
-      name: git-url
-      type: string
-    - default: ""
-      description: Revision of the Source Repository
-      name: revision
-      type: string
-    - description: Fully Qualified Output Image
-      name: output-image
-      type: string
-    - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
-      name: path-context
-      type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
-      name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
-      type: string
-    - default: "false"
-      description: Skip checks against built image
-      name: skip-checks
-      type: string
-    - default: "false"
-      description: Execute the build with network isolation
-      name: hermetic
-      type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
-      name: prefetch-input
-      type: string
-
-    - default: "false"
-      description: Java build
-      name: java
-      type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
-      name: image-expires-after
-    - default: "false"
-      description: Build a source image.
-      name: build-source-image
-      type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
-      name: build-args
-      type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-      name: build-args-file
-      type: string
-    results:
-    - description: ""
-      name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
-    - description: ""
-      name: IMAGE_DIGEST
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
-    - description: ""
-      name: CHAINS-GIT_URL
-      value: $(tasks.clone-repository.results.url)
-    - description: ""
-      name: CHAINS-GIT_COMMIT
-      value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
-    tasks:
-    - name: init
-      params:
-      - name: image-url
-        value: $(params.output-image)
-      - name: rebuild
-        value: $(params.rebuild)
-      - name: skip-checks
-        value: $(params.skip-checks)
-      taskRef:
-        params:
-        - name: name
-          value: init
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: clone-repository
-      params:
-      - name: url
-        value: $(params.git-url)
-      - name: revision
-        value: $(params.revision)
-      runAfter:
-      - init
-      taskRef:
-        params:
-        - name: name
-          value: git-clone
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: output
-        workspace: workspace
-      - name: basic-auth
-        workspace: git-auth
-    - name: prefetch-dependencies
-      params:
-      - name: input
-        value: $(params.prefetch-input)
-      runAfter:
-      - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: prefetch-dependencies
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:398d8333d30ea25ec1f766009c960df8dd42e0e3af7b2d782236dbde9a9f4bd9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.prefetch-input)
-        operator: notin
-        values:
-        - ""
-      workspaces:
-      - name: source
-        workspace: workspace
-      - name: git-basic-auth
-        workspace: git-auth
-      - name: netrc
-        workspace: netrc
-    - name: build-container
-      params:
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      runAfter:
-      - prefetch-dependencies
-      taskRef:
-        params:
-        - name: name
-          value: buildah
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:f93024e3dbcd41dcf1d7e30b3151032808211c39ad0a5ea03ea9c4d5274fa8dd
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: source
-        workspace: workspace
-    - name: build-source-image
-      params:
-      - name: BINARY_IMAGE
-        value: $(params.output-image)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: source-build
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.1@sha256:1cb3423593145e899b784000f6ae90e121763ce98c26f6fc049f5dee2310f805
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      - input: $(params.build-source-image)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    - name: deprecated-base-image-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: deprecated-image-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:3ac359dfc034948d59b9e8d507a8cf505a19b205c543e4c861a332c6f82a0307
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:a4dc853e50a31272d45aef8e8bdc7dac0f0f92212fc7bf8bab67ba5917c03405
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.1@sha256:9268ed0a50a87f27aedc048f69dff69b2a68d5aa3aca9ab7b65fe5a9f235d0c2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    - name: clamav-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clamav-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b494d21c755f5142f74441df3dc204a1d357a0fc339ac5a8000b80dc983182f9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:80a4d5df9d56b93a98fdca5d5fa6d7ecdb9731cdffd1c16bf51ee11e49984140
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: apply-tags
-      params:
-      - name: IMAGE
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: apply-tags
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: push-dockerfile
-      params:
-      - name: IMAGE
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: push-dockerfile
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:e2c8fa67da036cef81e407e28c14b6a2034c6564009e084c368005a4640c554c
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    workspaces:
-    - name: workspace
-    - name: git-auth
-      optional: true
-    - name: netrc
-      optional: true
-  taskRunTemplate: {}
-  workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-      status: {}
-  - name: git-auth
-    secret:
-      secretName: '{{ git_auth_secret }}'
-status: {}
+#apiVersion: tekton.dev/v1
+#kind: PipelineRun
+#metadata:
+#  annotations:
+#    build.appstudio.openshift.io/repo: https://github.com/gsaslis/marin3r?rev={{revision}}
+#    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+#    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+#    pipelinesascode.tekton.dev/max-keep-runs: "3"
+#    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+#      == "main"
+#  creationTimestamp: null
+#  labels:
+#    appstudio.openshift.io/application: marin3r
+#    appstudio.openshift.io/component: marin3r
+#    pipelines.appstudio.openshift.io/type: build
+#  name: marin3r-on-push
+#  namespace: rh-ee-gsaslisl-tenant
+#spec:
+#  params:
+#  - name: git-url
+#    value: '{{source_url}}'
+#  - name: revision
+#    value: '{{revision}}'
+#  - name: output-image
+#    value: quay.io/redhat-user-workloads/rh-ee-gsaslisl-tenant/marin3r/marin3r:{{revision}}
+#  - name: dockerfile
+#    value: Dockerfile
+#  - name: prefetch-input
+#    value: '{"type": "gomod", "path": "."}'
+#  - name: hermetic
+#    value: "true"
+#  pipelineSpec:
+#    finally:
+#    - name: show-sbom
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: show-sbom
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: show-summary
+#      params:
+#      - name: pipelinerun-name
+#        value: $(context.pipelineRun.name)
+#      - name: git-url
+#        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+#      - name: image-url
+#        value: $(params.output-image)
+#      - name: build-task-status
+#        value: $(tasks.build-container.status)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: summary
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    params:
+#    - description: Source Repository URL
+#      name: git-url
+#      type: string
+#    - default: ""
+#      description: Revision of the Source Repository
+#      name: revision
+#      type: string
+#    - description: Fully Qualified Output Image
+#      name: output-image
+#      type: string
+#    - default: .
+#      description: Path to the source code of an application's component from where
+#        to build image.
+#      name: path-context
+#      type: string
+#    - default: Dockerfile
+#      description: Path to the Dockerfile inside the context specified by parameter
+#        path-context
+#      name: dockerfile
+#      type: string
+#    - default: "false"
+#      description: Force rebuild image
+#      name: rebuild
+#      type: string
+#    - default: "false"
+#      description: Skip checks against built image
+#      name: skip-checks
+#      type: string
+#    - default: "false"
+#      description: Execute the build with network isolation
+#      name: hermetic
+#      type: string
+#    - default: ""
+#      description: Build dependencies to be prefetched by Cachi2
+#      name: prefetch-input
+#      type: string
+#
+#    - default: "false"
+#      description: Java build
+#      name: java
+#      type: string
+#    - default: ""
+#      description: Image tag expiration time, time values could be something like
+#        1h, 2d, 3w for hours, days, and weeks, respectively.
+#      name: image-expires-after
+#    - default: "false"
+#      description: Build a source image.
+#      name: build-source-image
+#      type: string
+#    - default: []
+#      description: Array of --build-arg values ("arg=value" strings) for buildah
+#      name: build-args
+#      type: array
+#    - default: ""
+#      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+#      name: build-args-file
+#      type: string
+#    results:
+#    - description: ""
+#      name: IMAGE_URL
+#      value: $(tasks.build-container.results.IMAGE_URL)
+#    - description: ""
+#      name: IMAGE_DIGEST
+#      value: $(tasks.build-container.results.IMAGE_DIGEST)
+#    - description: ""
+#      name: CHAINS-GIT_URL
+#      value: $(tasks.clone-repository.results.url)
+#    - description: ""
+#      name: CHAINS-GIT_COMMIT
+#      value: $(tasks.clone-repository.results.commit)
+#    - description: ""
+#      name: JAVA_COMMUNITY_DEPENDENCIES
+#      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+#    tasks:
+#    - name: init
+#      params:
+#      - name: image-url
+#        value: $(params.output-image)
+#      - name: rebuild
+#        value: $(params.rebuild)
+#      - name: skip-checks
+#        value: $(params.skip-checks)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: init
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: clone-repository
+#      params:
+#      - name: url
+#        value: $(params.git-url)
+#      - name: revision
+#        value: $(params.revision)
+#      runAfter:
+#      - init
+#      taskRef:
+#        params:
+#        - name: name
+#          value: git-clone
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: output
+#        workspace: workspace
+#      - name: basic-auth
+#        workspace: git-auth
+#    - name: prefetch-dependencies
+#      params:
+#      - name: input
+#        value: $(params.prefetch-input)
+#      runAfter:
+#      - clone-repository
+#      taskRef:
+#        params:
+#        - name: name
+#          value: prefetch-dependencies
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:398d8333d30ea25ec1f766009c960df8dd42e0e3af7b2d782236dbde9a9f4bd9
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.prefetch-input)
+#        operator: notin
+#        values:
+#        - ""
+#      workspaces:
+#      - name: source
+#        workspace: workspace
+#      - name: git-basic-auth
+#        workspace: git-auth
+#      - name: netrc
+#        workspace: netrc
+#    - name: build-container
+#      params:
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      runAfter:
+#      - prefetch-dependencies
+#      taskRef:
+#        params:
+#        - name: name
+#          value: buildah
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:f93024e3dbcd41dcf1d7e30b3151032808211c39ad0a5ea03ea9c4d5274fa8dd
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: source
+#        workspace: workspace
+#    - name: build-source-image
+#      params:
+#      - name: BINARY_IMAGE
+#        value: $(params.output-image)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: source-build
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.1@sha256:1cb3423593145e899b784000f6ae90e121763ce98c26f6fc049f5dee2310f805
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      - input: $(params.build-source-image)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    - name: deprecated-base-image-check
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: deprecated-image-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: clair-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clair-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:3ac359dfc034948d59b9e8d507a8cf505a19b205c543e4c861a332c6f82a0307
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:a4dc853e50a31272d45aef8e8bdc7dac0f0f92212fc7bf8bab67ba5917c03405
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: sast-snyk-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-snyk-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.1@sha256:9268ed0a50a87f27aedc048f69dff69b2a68d5aa3aca9ab7b65fe5a9f235d0c2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    - name: clamav-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clamav-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b494d21c755f5142f74441df3dc204a1d357a0fc339ac5a8000b80dc983182f9
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: sbom-json-check
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sbom-json-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:80a4d5df9d56b93a98fdca5d5fa6d7ecdb9731cdffd1c16bf51ee11e49984140
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: apply-tags
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: apply-tags
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: push-dockerfile
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-container.results.IMAGE_DIGEST)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: push-dockerfile
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:e2c8fa67da036cef81e407e28c14b6a2034c6564009e084c368005a4640c554c
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      workspaces:
+#      - name: workspace
+#        workspace: workspace
+#    workspaces:
+#    - name: workspace
+#    - name: git-auth
+#      optional: true
+#    - name: netrc
+#      optional: true
+#  taskRunTemplate: {}
+#  workspaces:
+#  - name: workspace
+#    volumeClaimTemplate:
+#      metadata:
+#        creationTimestamp: null
+#      spec:
+#        accessModes:
+#        - ReadWriteOnce
+#        resources:
+#          requests:
+#            storage: 1Gi
+#      status: {}
+#  - name: git-auth
+#    secret:
+#      secretName: '{{ git_auth_secret }}'
+#status: {}

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -1,0 +1,598 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: multi-arch-build-pipeline
+spec:
+  tasks:
+    - name: init
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
+          - name: kind
+            value: task
+      params:
+        - name: image-url
+          value: "$(params.output-image)"
+        - name: rebuild
+          value: "$(params.rebuild)"
+        - name: skip-checks
+          value: "$(params.skip-checks)"
+    - name: clone-repository
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: git-clone-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:cb23ff0e47501f7badac0b0ce61ca6ba4a1ada79352835272c440001a2a2c0c1
+          - name: kind
+            value: task
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+      runAfter:
+        - init
+      params:
+        - name: url
+          value: "$(params.git-url)"
+        - name: revision
+          value: "$(params.revision)"
+        - name: ociStorage
+          value: "$(params.output-image).git"
+        - name: ociArtifactExpiresAfter
+          value: "$(params.image-expires-after)"
+      workspaces:
+        - name: basic-auth
+          workspace: git-auth
+    - name: prefetch-dependencies
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:1e4787ce13ca515a70312c27e304ed6a1d3e63840863f4c841f2f1687d7df45f
+          - name: kind
+            value: task
+      params:
+        - name: input
+          value: "$(params.prefetch-input)"
+        - name: hermetic
+          value: "$(params.hermetic)"
+        - name: dev-package-managers
+          value: $(params.prefetch-dev-package-managers-enabled)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+    - name: build-container-amd64
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
+          - name: kind
+            value: task
+      runAfter:
+        - prefetch-dependencies
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.enable-amd64-build)"
+          operator: in
+          values:
+            - 'true'
+      params:
+        - name: IMAGE
+          value: "$(params.output-image)-amd64"
+        - name: DOCKERFILE
+          value: "$(params.dockerfile)"
+        - name: CONTEXT
+          value: "$(params.path-context)"
+        - name: HERMETIC
+          value: "$(params.hermetic)"
+        - name: PREFETCH_INPUT
+          value: "$(params.prefetch-input)"
+        - name: IMAGE_EXPIRES_AFTER
+          value: "$(params.image-expires-after)"
+        - name: COMMIT_SHA
+          value: "$(tasks.clone-repository.results.commit)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PLATFORM
+          value: $(params.amd64-platform)
+    - name: build-container-arm64
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
+          - name: kind
+            value: task
+      runAfter:
+        - prefetch-dependencies
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.enable-arm64-build)"
+          operator: in
+          values:
+            - 'true'
+      params:
+        - name: IMAGE
+          value: "$(params.output-image)-arm64"
+        - name: DOCKERFILE
+          value: "$(params.dockerfile)"
+        - name: CONTEXT
+          value: "$(params.path-context)"
+        - name: HERMETIC
+          value: "$(params.hermetic)"
+        - name: PREFETCH_INPUT
+          value: "$(params.prefetch-input)"
+        - name: IMAGE_EXPIRES_AFTER
+          value: "$(params.image-expires-after)"
+        - name: COMMIT_SHA
+          value: "$(tasks.clone-repository.results.commit)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PLATFORM
+          value: $(params.arm64-platform)
+    - name: build-container-ppc64le
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
+          - name: kind
+            value: task
+      runAfter:
+        - prefetch-dependencies
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.enable-ppc64le-build)"
+          operator: in
+          values:
+            - 'true'
+      params:
+        - name: IMAGE
+          value: "$(params.output-image)-ppc64le"
+        - name: DOCKERFILE
+          value: "$(params.dockerfile)"
+        - name: CONTEXT
+          value: "$(params.path-context)"
+        - name: HERMETIC
+          value: "$(params.hermetic)"
+        - name: PREFETCH_INPUT
+          value: "$(params.prefetch-input)"
+        - name: IMAGE_EXPIRES_AFTER
+          value: "$(params.image-expires-after)"
+        - name: COMMIT_SHA
+          value: "$(tasks.clone-repository.results.commit)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PLATFORM
+          value: $(params.ppc64le-platform)
+    - name: build-container-s390x
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
+          - name: kind
+            value: task
+      runAfter:
+        - prefetch-dependencies
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.enable-s390x-build)"
+          operator: in
+          values:
+            - 'true'
+      params:
+        - name: IMAGE
+          value: "$(params.output-image)-s390x"
+        - name: DOCKERFILE
+          value: "$(params.dockerfile)"
+        - name: CONTEXT
+          value: "$(params.path-context)"
+        - name: HERMETIC
+          value: "$(params.hermetic)"
+        - name: PREFETCH_INPUT
+          value: "$(params.prefetch-input)"
+        - name: IMAGE_EXPIRES_AFTER
+          value: "$(params.image-expires-after)"
+        - name: COMMIT_SHA
+          value: "$(tasks.clone-repository.results.commit)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PLATFORM
+          value: $(params.s390x-platform)
+    - name: build-image-index
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: IMAGES
+          value:
+            - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
+            - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
+            - $(tasks.build-container-s390x.results.IMAGE_URL)@$(tasks.build-container-s390x.results.IMAGE_DIGEST)
+            - $(tasks.build-container-ppc64le.results.IMAGE_URL)@$(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
+      runAfter:
+        - build-container-amd64
+        - build-container-arm64
+        - build-container-s390x
+        - build-container-ppc64le
+      taskRef:
+        params:
+          - name: name
+            value: build-image-manifest
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:231b521c5443a750cfcb302b74633ebe140b5ab0333688c91d32745417cc23a3
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+    - name: build-source-image
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: source-build-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:99ee22c5e8e8a66da3d68ec5f3334e7cc59f8b8907e9d2a78f7338aa37d952eb
+          - name: kind
+            value: task
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.build-source-image)"
+          operator: in
+          values:
+            - 'true'
+      runAfter:
+        - build-image-index
+      params:
+        - name: BINARY_IMAGE
+          value: "$(params.output-image)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: deprecated-base-image-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: deprecated-image-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:ea275aeb7d204ef203a67e6a45a4902479afc1d906d2120f0d8c77d9541ea850
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: clair-scan
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: clair-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:a13278c3ee419db573a3919d8f86091497d2e7b52b5a800c2767c265df51c58a
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: image-digest
+          value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: ecosystem-cert-preflight-checks
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: ecosystem-cert-preflight-checks
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:f0b2ee5d02fdff0ea32af13e26f481f6b66bddfc1357cf171b8e7525a38f09d4
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: image-url
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: sast-snyk-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: sast-snyk-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:d1989870f1078f164eb90848005a2cdcbf0df4dd2d357f7c35ff39cac3ec43e2
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: image-digest
+          value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: clamav-scan
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: clamav-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:a5742024c2755d3636110aea0b86d298660bb8b7708894674baec16bb90b7106
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: image-digest
+          value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: sbom-json-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: sbom-json-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:acc9cb8a714f33c0e48d6ca219b6bd0191f09cdd767af4ef3a35d0a5cac53b5d
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-image-index
+      params:
+        - name: IMAGE_URL
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+        - name: IMAGE_DIGEST
+          value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    - name: apply-tags
+      params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: apply-tags
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
+          - name: kind
+            value: task
+        resolver: bundles
+  params:
+    - name: git-url
+      type: string
+      description: Source Repository URL
+    - name: revision
+      type: string
+      description: Revision of the Source Repository
+      default: ''
+    - name: output-image
+      type: string
+      description: Fully Qualified Output Image
+    - name: path-context
+      type: string
+      description: Path to the source code of an application's component from where to
+        build image.
+      default: "."
+    - name: dockerfile
+      type: string
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      default: Dockerfile
+    - name: rebuild
+      type: string
+      description: Force rebuild image
+      default: 'false'
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ''
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: "true"
+      description: Enable dev-package-managers in prefetch task
+      name: prefetch-dev-package-managers-enabled
+      type: string
+    - name: java
+      type: string
+      description: Java build
+      default: 'false'
+    - name: image-expires-after
+      description: Image tag expiration time, time values could be something like 1h,
+        2d, 3w for hours, days, and weeks, respectively.
+      default: ''
+    - name: build-source-image
+      type: string
+      description: Build a source image.
+      default: 'false'
+    - name: build-args-file
+      type: string
+      description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
+    # We need matrix builds in order to use these "enable architecture" parameters: https://issues.redhat.com/browse/EC-654
+    - name: enable-amd64-build
+      type: string
+      description: Enable amd64 builds
+      default: "true"
+    - name: enable-arm64-build
+      type: string
+      description: Enable arm64 builds
+      default: "true"
+    - name: enable-ppc64le-build
+      type: string
+      description: Enable ppc64le builds
+      default: "true"
+    - name: enable-s390x-build
+      type: string
+      description: Enable s390x builds
+      default: "true"
+    - name: amd64-platform
+      type: string
+      description: Enable the amd64 platform to be changed from the PipelineRun file
+      default: linux/amd64
+    - name: arm64-platform
+      type: string
+      description: Enable the arm64 platform to be changed from the PipelineRun file
+      default: linux/arm64
+    - name: ppc64le-platform
+      type: string
+      description: Enable the ppc64le platform to be changed from the PipelineRun file
+      default: linux/ppc64le
+    - name: s390x-platform
+      type: string
+      description: Enable the s390x platform to be changed from the PipelineRun file
+      default: linux/s390x
+  workspaces:
+    - name: git-auth
+      optional: true
+  results:
+    - name: IMAGE_URL
+      description: ''
+      value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: IMAGE_DIGEST
+      description: ''
+      value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    - name: CHAINS-GIT_URL
+      description: ''
+      value: "$(tasks.clone-repository.results.url)"
+    - name: CHAINS-GIT_COMMIT
+      description: ''
+      value: "$(tasks.clone-repository.results.commit)"
+    - name: JAVA_COMMUNITY_DEPENDENCIES
+      description: ''
+      value: "$(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)"
+  finally:
+    - name: show-sbom
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: show-sbom
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
+          - name: kind
+            value: task
+      params:
+        - name: IMAGE_URL
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
+    - name: show-summary
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: summary
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
+          - name: kind
+            value: task
+      params:
+        - name: pipelinerun-name
+          value: "$(context.pipelineRun.name)"
+        - name: git-url
+          value: "$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)"
+        - name: image-url
+          value: "$(params.output-image)"
+        - name: build-task-status
+          value: "$(tasks.build-image-index.status)"

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -1,0 +1,375 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: single-arch-build-pipeline
+spec:
+  tasks:
+    - name: init
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
+          - name: kind
+            value: task
+      params:
+        - name: image-url
+          value: "$(params.output-image)"
+        - name: rebuild
+          value: "$(params.rebuild)"
+        - name: skip-checks
+          value: "$(params.skip-checks)"
+    - name: clone-repository
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: git-clone-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:cb23ff0e47501f7badac0b0ce61ca6ba4a1ada79352835272c440001a2a2c0c1
+          - name: kind
+            value: task
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+      runAfter:
+        - init
+      params:
+        - name: url
+          value: "$(params.git-url)"
+        - name: revision
+          value: "$(params.revision)"
+        - name: ociStorage
+          value: "$(params.output-image).git"
+        - name: ociArtifactExpiresAfter
+          value: "$(params.image-expires-after)"
+      workspaces:
+        - name: basic-auth
+          workspace: git-auth
+    - name: prefetch-dependencies
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:1e4787ce13ca515a70312c27e304ed6a1d3e63840863f4c841f2f1687d7df45f
+          - name: kind
+            value: task
+      params:
+        - name: input
+          value: "$(params.prefetch-input)"
+        - name: hermetic
+          value: "$(params.hermetic)"
+        - name: dev-package-managers
+          value: $(params.prefetch-dev-package-managers-enabled)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+    - name: build-container
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: buildah-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:5a4b169dc50d787613de6bce76d1c728c4a8f5981f0e34358b41d74d4b20d20c
+          - name: kind
+            value: task
+      runAfter:
+        - clone-repository
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+      params:
+        - name: IMAGE
+          value: "$(params.output-image)"
+        - name: DOCKERFILE
+          value: "$(params.dockerfile)"
+        - name: CONTEXT
+          value: "$(params.path-context)"
+        - name: HERMETIC
+          value: "$(params.hermetic)"
+        - name: PREFETCH_INPUT
+          value: "$(params.prefetch-input)"
+        - name: IMAGE_EXPIRES_AFTER
+          value: "$(params.image-expires-after)"
+        - name: COMMIT_SHA
+          value: "$(tasks.clone-repository.results.commit)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: build-source-image
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: source-build-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:99ee22c5e8e8a66da3d68ec5f3334e7cc59f8b8907e9d2a78f7338aa37d952eb
+          - name: kind
+            value: task
+      when:
+        - input: "$(tasks.init.results.build)"
+          operator: in
+          values:
+            - 'true'
+        - input: "$(params.build-source-image)"
+          operator: in
+          values:
+            - 'true'
+      runAfter:
+        - build-container
+      params:
+        - name: BINARY_IMAGE
+          value: "$(params.output-image)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: deprecated-base-image-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: deprecated-image-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:ea275aeb7d204ef203a67e6a45a4902479afc1d906d2120f0d8c77d9541ea850
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-container.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: clair-scan
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: clair-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:a13278c3ee419db573a3919d8f86091497d2e7b52b5a800c2767c265df51c58a
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: image-digest
+          value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: ecosystem-cert-preflight-checks
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: ecosystem-cert-preflight-checks
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:f0b2ee5d02fdff0ea32af13e26f481f6b66bddfc1357cf171b8e7525a38f09d4
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: image-url
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: sast-snyk-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: sast-snyk-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:d1989870f1078f164eb90848005a2cdcbf0df4dd2d357f7c35ff39cac3ec43e2
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: image-digest
+          value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: clamav-scan
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: clamav-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:a5742024c2755d3636110aea0b86d298660bb8b7708894674baec16bb90b7106
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: image-digest
+          value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+        - name: image-url
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: sbom-json-check
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: sbom-json-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:acc9cb8a714f33c0e48d6ca219b6bd0191f09cdd767af4ef3a35d0a5cac53b5d
+          - name: kind
+            value: task
+      when:
+        - input: "$(params.skip-checks)"
+          operator: in
+          values:
+            - 'false'
+      runAfter:
+        - build-container
+      params:
+        - name: IMAGE_URL
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+        - name: IMAGE_DIGEST
+          value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+  params:
+    - name: git-url
+      type: string
+      description: Source Repository URL
+    - name: revision
+      type: string
+      description: Revision of the Source Repository
+      default: ''
+    - name: output-image
+      type: string
+      description: Fully Qualified Output Image
+    - name: path-context
+      type: string
+      description: Path to the source code of an application's component from where to
+        build image.
+      default: "."
+    - name: dockerfile
+      type: string
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      default: Dockerfile
+    - name: rebuild
+      type: string
+      description: Force rebuild image
+      default: 'false'
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ''
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: "false"
+      description: Enable dev-package-managers in prefetch task
+      name: prefetch-dev-package-managers-enabled
+      type: string
+    - name: java
+      type: string
+      description: Java build
+      default: 'false'
+    - name: image-expires-after
+      description: Image tag expiration time, time values could be something like 1h,
+        2d, 3w for hours, days, and weeks, respectively.
+      default: ''
+    - name: build-source-image
+      type: string
+      description: Build a source image.
+      default: 'false'
+  workspaces:
+    - name: git-auth
+      optional: true
+  results:
+    - name: IMAGE_URL
+      description: ''
+      value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: IMAGE_DIGEST
+      description: ''
+      value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+    - name: CHAINS-GIT_URL
+      description: ''
+      value: "$(tasks.clone-repository.results.url)"
+    - name: CHAINS-GIT_COMMIT
+      description: ''
+      value: "$(tasks.clone-repository.results.commit)"
+    - name: JAVA_COMMUNITY_DEPENDENCIES
+      description: ''
+      value: "$(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)"
+  finally:
+    - name: show-sbom
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: show-sbom
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:7f8b5499a21de9aca718d0cf2e170949af6b30cacf882d64983471a2c673b1da
+          - name: kind
+            value: task
+      params:
+        - name: IMAGE_URL
+          value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: show-summary
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: summary
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
+          - name: kind
+            value: task
+      params:
+        - name: pipelinerun-name
+          value: "$(context.pipelineRun.name)"
+        - name: git-url
+          value: "$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)"
+        - name: image-url
+          value: "$(params.output-image)"
+        - name: build-task-status
+          value: "$(tasks.build-container.status)"


### PR DESCRIPTION
as per sample on: https://github.com/konflux-ci/olm-operator-konflux-sample/tree/main

enables multi-arch builds for operands and single-arch build for operator bundle

as per the docs:

Bundle images SHOULD NOT be built as multi-arch components (i.e. the pipelines should only produce a single OCI Image Manifest and should not produce an OCI Image Index which references an Image Manifest for each architecture).

source: https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/building-olm-products.md#building-bundle-images